### PR TITLE
Refactor implementation to use a global timer

### DIFF
--- a/Sources/Dock.swift
+++ b/Sources/Dock.swift
@@ -5,6 +5,32 @@ class Dock {
     [.optionOnScreenOnly, .excludeDesktopElements]
   }
 
+  static func windowCount() -> Int {
+    guard let info = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as [AnyObject]? else {
+      return 0
+    }
+
+    return info.filter { entry in
+      guard let bounds = entry[kCGWindowBounds] as? NSDictionary,
+            let appName = entry[kCGWindowOwnerName] as? String,
+            let isOnScreen = entry[kCGWindowIsOnscreen] as? Bool,
+            let layer = entry[kCGWindowLayer] as? Int32,
+            appName != "Dock" else {
+        return false
+      }
+
+      guard bounds.object(forKey: "X") != nil else {
+        return false
+      }
+
+      let validLayerRange = 0...CGWindowLevelKey.desktopIconWindow.rawValue
+
+      guard validLayerRange.contains(layer) else { return false }
+
+      return true
+    }.count
+  }
+
   static func windowCount(for name: String) -> Int {
     guard let info = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as [AnyObject]? else {
       return 0

--- a/project.yml
+++ b/project.yml
@@ -23,10 +23,10 @@ targets:
       groups: [app]
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon"
-        CURRENT_PROJECT_VERSION: 1
+        CURRENT_PROJECT_VERSION: 2
         ENABLE_HARDENED_RUNTIME: true
         INFOPLIST_FILE: "Resources/Info.plist"
-        MARKETING_VERSION: 0.0.1
+        MARKETING_VERSION: 0.0.2
         PRODUCT_BUNDLE_IDENTIFIER: "com.zenangst.Houston"
         PRODUCT_NAME: "Houston"
     entitlements:


### PR DESCRIPTION
- Remove the polling functionality in favor of a global timer
- Add new windowCount() method on `Dock`
