### PR TITLE
Fix realignment being called twice

### DIFF
--- a/Sources/MissionControl.swift
+++ b/Sources/MissionControl.swift
@@ -1,21 +1,26 @@
 import Cocoa
 
 enum MissionControl {
+  typealias CompletionHandler = (() -> Void)?
   /// Open the Mission Control application
   /// - Parameter handler: A completion closure that is called
   ///                      directly after the open application invocation
   ///                      occurred.
-  static func open(then handler: (() -> Void)? = nil) {
+  static func open(then handler: CompletionHandler = nil) {
     let path = "/System/Applications/Mission Control.app"
     NSWorkspace.shared.open(URL(fileURLWithPath: path))
     handler?()
   }
 
-  static func realign() {
+  static func realign(then handler: CompletionHandler = nil) {
     MissionControl.open {
       // TODO: Should this be a preference that you can toggle on and off?
       let deadline = DispatchTime.now() + NSAnimationContext.current.duration + 0.035
-      DispatchQueue.main.asyncAfter(deadline: deadline) { MissionControl.open() }
+      DispatchQueue.main.asyncAfter(deadline: deadline) {
+        MissionControl.open {
+          handler?()
+        }
+      }
     }
   }
 }

--- a/Sources/TimerController.swift
+++ b/Sources/TimerController.swift
@@ -21,7 +21,10 @@ final class TimerController {
 
     let windowCount = WindowManager.windowCount()
     if windowCount > session.windowCount {
-      MissionControl.realign()
+      self.timer = nil
+      MissionControl.realign {
+        self.addTimer()
+      }
     }
     session.windowCount = windowCount
   }

--- a/project.yml
+++ b/project.yml
@@ -23,10 +23,10 @@ targets:
       groups: [app]
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon"
-        CURRENT_PROJECT_VERSION: 4
+        CURRENT_PROJECT_VERSION: 5
         ENABLE_HARDENED_RUNTIME: true
         INFOPLIST_FILE: "Resources/Info.plist"
-        MARKETING_VERSION: 0.0.4
+        MARKETING_VERSION: 0.0.5
         PRODUCT_BUNDLE_IDENTIFIER: "com.zenangst.Houston"
         PRODUCT_NAME: "Houston"
     entitlements:


### PR DESCRIPTION
- Remove timer when invoking MissionControl.realign and re-add the timer
  when the operation is done to ensure that we don't trigger realignment
  while the process is already running.
